### PR TITLE
FIX: tag click error

### DIFF
--- a/src/containers/TagPickerPopoverContainer.js
+++ b/src/containers/TagPickerPopoverContainer.js
@@ -6,31 +6,31 @@ import TagPickerPopover from '../components/TagPickerPopover';
 import * as TagActions from '../actions/TagActions';
 
 class TagPickerPopoverContainer extends Component {
-  render() {
-    return <TagPickerPopover {...this.props} />;
-  }
+	render () {
+		return <TagPickerPopover {...this.props} />;
+	}
 }
 
-function mapStateToProps(state) {
-  const {
+function mapStateToProps (state) {
+	const {
     entities,
 		router,
   } = state;
 	const tagged = {};
-	Object.keys(entities.tags).forEach(tag => {
-		tagged[tag] = false;
-	});
-	entities.notes[router.params.noteId].tags.forEach(tag => {
-		tagged[tag] = true;
-	});
+	const noteId = router.params.noteId;
+	const TAGKEYS = entities.tags && Object.keys(entities.tags);
+	const TAGS = entities.notes[noteId] && entities.notes[noteId].tags;
+	const TAGKEYSSET = (TAGKEYS, bool) => TAGKEYS.forEach(tag => tagged[tag] = bool);
+	TAGS && TAGKEYSSET(TAGS, true);
+	TAGKEYS && TAGKEYSSET(TAGKEYS, false);
 	return {
 		tagged,
-		noteId: router.params.noteId,
+		noteId,
 	};
 }
 
-function mapDispatchToProps(dispatch) {
-  return bindActionCreators(TagActions, dispatch);
+function mapDispatchToProps (dispatch) {
+	return bindActionCreators(TagActions, dispatch);
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(TagPickerPopoverContainer);

--- a/src/reducers/entities/notebooks.js
+++ b/src/reducers/entities/notebooks.js
@@ -4,7 +4,7 @@ import remove from 'lodash/remove';
 
 import * as types from '../../constants/ActionTypes';
 
-function notebooks(state = {}, action) {
+function notebooks (state = {}, action) {
   switch (action.type) {
     // FIXME: duplicate action reducer
     case types.ADD_NOTE:
@@ -13,8 +13,8 @@ function notebooks(state = {}, action) {
         [action.payload.notebookId]: {
           ...state[action.payload.notebookId],
           noteIds: [
-            ...state[action.payload.notebookId].noteIds,
             action.payload.note.noteId,
+            ...state[action.payload.notebookId].noteIds,
           ],
         }
       };
@@ -64,7 +64,7 @@ function notebooks(state = {}, action) {
       return state;
     case types.BATCH_SET_NOTEBOOKS:
       return {
-				...action.payload.entities.notebooks,
+        ...action.payload.entities.notebooks,
       };
     default:
       return state;


### PR DESCRIPTION
FIX: 在文本列表页中先点击其他空白部分，再点击标签页，会报错。